### PR TITLE
Added more Keywords from Docs

### DIFF
--- a/syntaxes/carbon.tmLanguage.json
+++ b/syntaxes/carbon.tmLanguage.json
@@ -31,8 +31,12 @@
 					"match": "\\b(__continuation|__run|__await)\\b"
 				},
 				{
+					"name": "keyword.WIP.carbon",
+					"match": "\\b(base|abstract|virtual|protected|destructor|namespace|private)\\b"
+				},
+				{
 					"name": "keyword.other.carbon",
-					"match": "\\b(import|package|library|api|alias|external|where|returned|library|and)\\b"
+					"match": "\\b(import|package|library|api|alias|external|where|returned|library|and|addr)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
Added more Keywords from the official [Docs](https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/README.mdl), including WIP Keywords.